### PR TITLE
Implement #2 - Initial user/role setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # Created by https://www.gitignore.io/api/react,reactnative
 # Edit at https://www.gitignore.io/?templates=react,reactnative
 
-**/SetupTestUsers.java
-
 .settings/
 
 # Following 3 lines were here when we cloned startcode:

--- a/.gitignore
+++ b/.gitignore
@@ -586,8 +586,6 @@
 
 /nbproject/
 
-**/SetupTestUsers.java
-
 # Created by https://www.gitignore.io/api/intellij+all
 # Edit at https://www.gitignore.io/?templates=intellij+all
 

--- a/src/main/java/utils/SetupTestUsers.java
+++ b/src/main/java/utils/SetupTestUsers.java
@@ -1,0 +1,45 @@
+package utils;
+
+import entities.Role;
+import entities.User;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+public class SetupTestUsers {
+
+    public static void main(String[] args) {
+
+        EntityManagerFactory emf = EMF_Creator.createEntityManagerFactory(EMF_Creator.DbSelector.DEV, EMF_Creator.Strategy.CREATE);
+        EntityManager em = emf.createEntityManager();
+
+        // IMPORTAAAAAAAAAANT!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        // This breaks one of the MOST fundamental security rules in that it ships with default users and passwords
+        // CHANGE the three passwords below, before you uncomment and execute the code below
+        // Also, either delete this file, when users are created or rename and add to .gitignore
+        // Whatever you do DO NOT COMMIT and PUSH with the real passwords
+        System.out.println("-----------------------------");
+        System.out.println("CHANGE DEFAULT PASSWORDS BEFORE PRODUCTION - SEE utils.SetupTestUsers.java");
+        System.out.println("-----------------------------");
+        User user = new User("user", "user");
+        User admin = new User("admin", "admin");
+        User both = new User("both", "both");
+
+        em.getTransaction().begin();
+        Role userRole = new Role("user");
+        Role adminRole = new Role("admin");
+        user.addRole(userRole);
+        admin.addRole(adminRole);
+        both.addRole(userRole);
+        both.addRole(adminRole);
+        em.persist(userRole);
+        em.persist(adminRole);
+        em.persist(user);
+        em.persist(admin);
+        em.persist(both);
+        em.getTransaction().commit();
+        System.out.println("PW HASH CHECK: " + user.getUserPass());
+        System.out.println("Created TEST Users");
+    }
+
+}


### PR DESCRIPTION
Fixes #2

I have added some remarks in #15 regarding this setup as well as added a warning in this code.
I wanted to add some error-handling as there were in the startcode* but I couldn't really do it with hashing implemented. (*[Reference](https://github.com/dat3startcode/rest-jpa-devops-startcode/blob/security/src/main/java/utils/SetupTestUsers.java#L27))

### Can only be run once  
![image](https://user-images.githubusercontent.com/37186286/68686441-efbcf880-056b-11ea-95b4-e2e9234dac7a.png)
I considered adding a feature for allowing it to run multiple times, but it's not *needed*. I also think it would be bad to have destructive operations here.

### Showcasing DB
![image](https://user-images.githubusercontent.com/37186286/68686691-4c201800-056c-11ea-82a4-d94245dc3d55.png)
This is the result. Note that hashing is already implemented, so if you haven't seen it, I have closed #6 