### PR TITLE
Implement #20 - Endpoint that handles multiple roles

### DIFF
--- a/src/main/java/rest/DemoResource.java
+++ b/src/main/java/rest/DemoResource.java
@@ -79,7 +79,7 @@ public class DemoResource {
     @RolesAllowed({"admin", "user"})
     public String getMultipleRoles() {
         String thisuser = securityContext.getUserPrincipal().getName();
-        return "{\"msg\": \"Hello to (admin OR user) User: " + thisuser + "\"}";
+        return "{\"msg\": \"Hello to (admin OR user, but not a nobody) User: " + thisuser + "\"}";
     }
     
     /**
@@ -91,7 +91,7 @@ public class DemoResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("bothrestricted")
-    @RolesAllowed(value = {"admin","user"})
+    @RolesAllowed(value = {"admin, user"})
     public String getBothRoles() {
         String thisuser = securityContext.getUserPrincipal().getName();
         return "{\"msg\": \"Hello to (superuser) User: " + thisuser + "\"}";

--- a/src/main/java/rest/DemoResource.java
+++ b/src/main/java/rest/DemoResource.java
@@ -67,4 +67,33 @@ public class DemoResource {
         String thisuser = securityContext.getUserPrincipal().getName();
         return "{\"msg\": \"Hello to (admin) User: " + thisuser + "\"}";
     }
+    
+    /**
+     * The idea is here, that this endpoint is only available to registered users (and admins)
+     * While the allUsers (/all) endpoint is available to anyone
+     * @return 
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("both")
+    @RolesAllowed({"admin", "user"})
+    public String getMultipleRoles() {
+        String thisuser = securityContext.getUserPrincipal().getName();
+        return "{\"msg\": \"Hello to (admin OR user) User: " + thisuser + "\"}";
+    }
+    
+    /**
+     * DEPRECATED: DONT THINK THIS IS POSSIBLE.
+     * Only accessible by a super-user (that holds both admin & user)
+     * @return 
+     */
+    @Deprecated
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("bothrestricted")
+    @RolesAllowed(value = {"admin","user"})
+    public String getBothRoles() {
+        String thisuser = securityContext.getUserPrincipal().getName();
+        return "{\"msg\": \"Hello to (superuser) User: " + thisuser + "\"}";
+    }
 }

--- a/src/test/java/rest/LoginEndpointTest.java
+++ b/src/test/java/rest/LoginEndpointTest.java
@@ -79,11 +79,13 @@ public class LoginEndpointTest {
             User both = new User("user_admin", "test");
             both.addRole(userRole);
             both.addRole(adminRole);
+            User nobody = new User("nobody", "test"); //no role connected
             em.persist(userRole);
             em.persist(adminRole);
             em.persist(user);
             em.persist(admin);
             em.persist(both);
+            em.persist(nobody);
             System.out.println("Saved test data to database");
             em.getTransaction().commit();
         } finally {
@@ -223,5 +225,54 @@ public class LoginEndpointTest {
             .body("message", equalTo("Not authenticated - do login"));
   }
     
+    /**
+     * Testing 'getMultipleRoles' endpoint. Meant to allow registered users only
+     *
+     * @RolesAllowed({"admin", "user"})
+     */
+    @Test
+    public void testMultipleRolesEndpoint_user() {
+        login("user", "test");
+        given()
+            .contentType("application/json")
+            .header("x-access-token", securityToken)
+            .when()
+            .get("/info/both").then()
+            .statusCode(200)
+            .body("msg", equalTo("Hello to (admin OR user, but not a nobody) User: user"));
+    }
     
+    /**
+     * Testing 'getMultipleRoles' endpoint. Meant to allow registered users only
+     *
+     * @RolesAllowed({"admin", "user"})
+     */
+    @Test
+    public void testMultipleRolesEndpoint_admin() {
+        login("admin", "test");
+        given()
+            .contentType("application/json")
+            .header("x-access-token", securityToken)
+            .when()
+            .get("/info/both").then()
+            .statusCode(200)
+            .body("msg", equalTo("Hello to (admin OR user, but not a nobody) User: admin"));
+    }
+    
+    /**
+     * Testing 'getMultipleRoles' endpoint. Meant to allow registered users only
+     *
+     * @RolesAllowed({"admin", "user"})
+     */
+    @Test
+    public void testMultipleRolesEndpoint_nobody() {
+        //login("nobody", "test");
+        given()
+                .contentType("application/json")
+                //.header("x-access-token", securityToken)
+                .when()
+                .get("/info/both").then().log().body()
+                .statusCode(403)
+                .body("message", equalTo("Not authenticated - do login"));
+    }
 }


### PR DESCRIPTION
Fixes #20 - sort of.

See some documentation in #20.

I saw that the `SetupTestUser` script had the following user:
```java
User both = new User("user_admin", "test");
both.addRole(userRole);
both.addRole(adminRole);
```
And I figured there should be an endpoint for this specific user.

However, as I have documented in the issue, rather than allowing access only to users who hold **both** roles, I have created an endpoint available to multiple, certain roles only. 

This could be useful if you had certain tier of users, think of managers vs owners or regular users vs VIP users.

I have kept the attempt in the code and deprecated it. It can be deleted.